### PR TITLE
Upgraded docker-deploy.sh script, added REST API tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,65 +33,80 @@ before_script:
 
 jobs:
   include:
-  - stage: build
+  - stage: Build
     script:
     - $M2_HOME/bin/mvn -v
     - $M2_HOME/bin/mvn -B ${BUILD_OPTS} -DskipTests clean install
-  - stage: test
+  - stage: REST API Tests
+    language: node_js
+    node_js: "12.0"
+    install:
+    - npm install newman
+    before_script:
+    - ./deployment/docker/unix/docker-deploy.sh
+    - docker ps -a
+    - node --version
+    - npm --version
+    - node_modules/.bin/newman --version
+    script:
+    - node_modules/.bin/newman run rest-api/test/KapuaApiTestingPostman_collection.json
+    after_script:
+    - ./deployment/docker/unix/docker-undeploy.sh
+  - stage: Unit & Integration Tests
     script:
     - ./travis.sh $M2_HOME/bin/mvn -B ${BUILD_OPTS} ${CONFIG_OVERRIDES} -Dgroups='!org.eclipse.kapua.qa.markers.junit.JUnitTests' -Dcucumber.options="--tags @brokerAcl" verify
-  - stage: test
+  - stage: Unit & Integration Tests
     script:
     - ./travis.sh $M2_HOME/bin/mvn -B ${BUILD_OPTS} ${CONFIG_OVERRIDES} -Dgroups='!org.eclipse.kapua.qa.markers.junit.JUnitTests' -Dcucumber.options="--tags @tag" verify
-  - stage: test
+  - stage: Unit & Integration Tests
     script:
     - ./travis.sh $M2_HOME/bin/mvn -B ${BUILD_OPTS} ${CONFIG_OVERRIDES} -Dgroups='!org.eclipse.kapua.qa.markers.junit.JUnitTests' -Dcucumber.options="--tags @broker" verify
-  - stage: test
+  - stage: Unit & Integration Tests
     script:
     - ./travis.sh $M2_HOME/bin/mvn -B ${BUILD_OPTS} ${CONFIG_OVERRIDES} -Dgroups='!org.eclipse.kapua.qa.markers.junit.JUnitTests' -Dcucumber.options="--tags @device" verify
-  - stage: test
+  - stage: Unit & Integration Tests
     script:
     - ./travis.sh $M2_HOME/bin/mvn -B ${BUILD_OPTS} ${CONFIG_OVERRIDES} -Dgroups='!org.eclipse.kapua.qa.markers.junit.JUnitTests' -Dcucumber.options="--tags @connection" verify
-  - stage: test
+  - stage: Unit & Integration Tests
     script:
     - ./travis.sh $M2_HOME/bin/mvn -B ${BUILD_OPTS} ${CONFIG_OVERRIDES} -Dgroups='!org.eclipse.kapua.qa.markers.junit.JUnitTests' -Dcucumber.options="--tags @datastore" verify
-  - stage: test
+  - stage: Unit & Integration Tests
     script:
     - ./travis.sh $M2_HOME/bin/mvn -B ${BUILD_OPTS} ${CONFIG_OVERRIDES} -Dgroups='!org.eclipse.kapua.qa.markers.junit.JUnitTests' -Dcucumber.options="--tags @user" verify
-  - stage: test
+  - stage: Unit & Integration Tests
     script:
     - ./travis.sh $M2_HOME/bin/mvn -B ${BUILD_OPTS} ${CONFIG_OVERRIDES} -Dgroups='!org.eclipse.kapua.qa.markers.junit.JUnitTests' -Dcucumber.options="--tags @security" verify
-  - stage: test
+  - stage: Unit & Integration Tests
     script:
     - ./travis.sh $M2_HOME/bin/mvn -B ${BUILD_OPTS} ${CONFIG_OVERRIDES} -Dgroups='!org.eclipse.kapua.qa.markers.junit.JUnitTests' -Dcucumber.options="--tags @jobs" verify
-  - stage: test
+  - stage: Unit & Integration Tests
     script:
     - ./travis.sh $M2_HOME/bin/mvn -B ${BUILD_OPTS} ${CONFIG_OVERRIDES} -Dgroups='!org.eclipse.kapua.qa.markers.junit.JUnitTests' -Dcucumber.options="--tags @triggerService" verify
-  - stage: test
+  - stage: Unit & Integration Tests
     script:
     - ./travis.sh $M2_HOME/bin/mvn -B ${BUILD_OPTS} ${CONFIG_OVERRIDES} -Dgroups='!org.eclipse.kapua.qa.markers.junit.JUnitTests' -Dcucumber.options="--tags @account" verify
-  - stage: test
+  - stage: Unit & Integration Tests
     script:
     - ./travis.sh $M2_HOME/bin/mvn -B ${BUILD_OPTS} ${CONFIG_OVERRIDES} -Dgroups='!org.eclipse.kapua.qa.markers.junit.JUnitTests' -Dcucumber.options="--tags @jobEngineStartOfflineDevice" verify
-  - stage: test
+  - stage: Unit & Integration Tests
     script:
     - ./travis.sh $M2_HOME/bin/mvn -B ${BUILD_OPTS} ${CONFIG_OVERRIDES} -Dgroups='!org.eclipse.kapua.qa.markers.junit.JUnitTests' -Dcucumber.options="--tags @jobEngineStartOnlineDevice" verify
-  - stage: test
+  - stage: Unit & Integration Tests
     script:
     - ./travis.sh $M2_HOME/bin/mvn -B ${BUILD_OPTS} ${CONFIG_OVERRIDES} -Dgroups='!org.eclipse.kapua.qa.markers.junit.JUnitTests' -Dcucumber.options="--tags @jobEngineRestartOfflineDevice" verify
-  - stage: test
+  - stage: Unit & Integration Tests
     script:
     - ./travis.sh $M2_HOME/bin/mvn -B ${BUILD_OPTS} ${CONFIG_OVERRIDES} -Dgroups='!org.eclipse.kapua.qa.markers.junit.JUnitTests' -Dcucumber.options="--tags @jobEngineRestartOnlineDevice" verify
-  - stage: test
+  - stage: Unit & Integration Tests
     script:
     - ./travis.sh $M2_HOME/bin/mvn -B ${BUILD_OPTS} ${CONFIG_OVERRIDES} -Dgroups='!org.eclipse.kapua.qa.markers.junit.JUnitTests' -Dcucumber.options="--tags @jobEngineRestartOnlineDeviceSecondPart" verify
-  - stage: test
+  - stage: Unit & Integration Tests
     script:
     - ./travis.sh $M2_HOME/bin/mvn -B ${BUILD_OPTS} ${CONFIG_OVERRIDES} -Dgroups='!org.eclipse.kapua.qa.markers.junit.JUnitTests' -Dcucumber.options="--tags @jobEngineServiceStop" verify
-  - stage: test
+  - stage: Unit & Integration Tests
     script:
     - ./travis.sh $M2_HOME/bin/mvn -B ${BUILD_OPTS} ${CONFIG_OVERRIDES} -Dgroups='org.eclipse.kapua.qa.markers.junit.JUnitTests' verify
-  - stage: test
+  - stage: Unit & Integration Tests
     script:
     - $M2_HOME/bin/mvn -B -DskipTests install javadoc:jar
 

--- a/deployment/docker/compose/docker-compose.yml
+++ b/deployment/docker/compose/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     image: kapua/kapua-sql:${IMAGE_VERSION}
     ports:
       - 8181:8181
-      - 3306:3306
+      - 3307:3307
   es:
     image: elasticsearch:5.4.0
     ports:

--- a/deployment/docker/unix/docker-deploy.sh
+++ b/deployment/docker/unix/docker-deploy.sh
@@ -61,6 +61,20 @@ docker_compose || {
     echo "Deploying Eclipse Kapua... ERROR!"
     exit 1
 }
+
+container=1
+while ((container)); do
+    echo "waiting for containers to start..."
+    docker logs compose_kapua-api_1 >& docker-log.log
+    if grep -q "org.eclipse.jetty.server.Server - Started" docker-log.log ; then
+        container=0  
+    else
+        sleep 5s
+    fi
+done
+echo "Docker containers are up and running!"
+rm docker-log.log
+
 echo "Deploying Eclipse Kapua... DONE!"
 
 if [[ -z "$1" ]]; then

--- a/rest-api/test/KapuaApiTestingPostman_collection.json
+++ b/rest-api/test/KapuaApiTestingPostman_collection.json
@@ -1,0 +1,1324 @@
+{
+	"info": {
+		"_postman_id": "90847948-be9c-41c5-b13c-0564b836422e",
+		"name": "Demo",
+		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+	},
+	"item": [
+		{
+			"name": "Login - Username and password",
+			"item": [
+				{
+					"name": "Login with correct username and password",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "16102ddb-cc37-4410-978e-ad5da17accf1",
+								"exec": [
+									"pm.test(\"Status code is 200\", function () {\r",
+									"    pm.response.to.have.status(200);\r",
+									"});\r",
+									"pm.test(\"Body matches string\", function () {\r",
+									"    pm.expect(pm.response.text()).to.include(\"type\");\r",
+									"    pm.expect(pm.response.text()).to.include(\"id\");\r",
+									"    pm.expect(pm.response.text()).to.include(\"scopeId\");\r",
+									"    pm.expect(pm.response.text()).to.include(\"createdOn\");\r",
+									"    pm.expect(pm.response.text()).to.include(\"createdBy\");\r",
+									"    pm.expect(pm.response.text()).to.include(\"modifiedOn\");\r",
+									"    pm.expect(pm.response.text()).to.include(\"modifiedBy\");\r",
+									"    pm.expect(pm.response.text()).to.include(\"optlock\");\r",
+									"    pm.expect(pm.response.text()).to.include(\"tokenId\");\r",
+									"    pm.expect(pm.response.text()).to.include(\"userId\");\r",
+									"    pm.expect(pm.response.text()).to.include(\"expiresOn\");\r",
+									"    pm.expect(pm.response.text()).to.include(\"refreshToken\");\r",
+									"    pm.expect(pm.response.text()).to.include(\"refreshExpiresOn\");\r",
+									"\r",
+									"});\r",
+									"// pm.globals.set(\"variable_key\", \"variable_value\");\r",
+									"var jsonData = JSON.parse(responseBody);\r",
+									"\r",
+									"pm.globals.set(\"jwttoken\", jsonData.tokenId);\r",
+									"console.log(\"token id after login is: \" + pm.globals.get(\"jwttoken\"));\r",
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"auth": {
+							"type": "noauth"
+						},
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\r\n  \"username\": \"kapua-sys\",\r\n  \"password\": \"kapua-password\"\r\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "http://localhost:8081/v1/authentication/user",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "8081",
+							"path": [
+								"v1",
+								"authentication",
+								"user"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Login with wrong username and password",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "2c6db04b-146e-4e21-86a6-52c6460c56c3",
+								"exec": [
+									"pm.test(\"Status code is 500\", function () {\r",
+									"    pm.response.to.have.status(500);\r",
+									"});\r",
+									"pm.test(\"Body matches string\", function () {\r",
+									"    pm.expect(pm.response.text()).to.include(\"type\");\r",
+									"    pm.expect(pm.response.text()).to.include(\"httpErrorCode\");\r",
+									"    pm.expect(pm.response.text()).to.include(\"message\");\r",
+									"    pm.expect(pm.response.text()).to.include(\"kapuaErrorCode\");\r",
+									"});\r",
+									"\r",
+									"var jsonData = pm.response.json(); \r",
+									"\r",
+									"    pm.test(\"Verify type\", function () { \r",
+									"        pm.expect(jsonData.type).is.to.equal(\"exceptionInfo\"); \r",
+									"    });\r",
+									"\r",
+									"    pm.test(\"Verify httpErrorCode\", function () { \r",
+									"        pm.expect(jsonData.httpErrorCode).is.to.equal(500); \r",
+									"    });\r",
+									"\r",
+									"    pm.test(\"Verify message\", function () { \r",
+									"        pm.expect(jsonData.message).is.to.equal(\"An internal error occurred: org.apache.shiro.ShiroException: Error while find user!.\"); \r",
+									"    });\r",
+									"\r",
+									"    pm.test(\"Verify kapuaErrorCode\", function () { \r",
+									"        pm.expect(jsonData.kapuaErrorCode).is.to.equal(\"INTERNAL_ERROR\"); \r",
+									"    });"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"protocolProfileBehavior": {
+						"strictSSL": true
+					},
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\r\n  \"message\": \"string\",\r\n  \"kapuaErrorCode\": \"string\"\r\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "http://localhost:8081/v1/authentication/user",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "8081",
+							"path": [
+								"v1",
+								"authentication",
+								"user"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Login with correct username and wrong password",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "e3f06466-34ab-421f-a0ed-66b1b7ac1c92",
+								"exec": [
+									"pm.test(\"Status code is 401\", function () {\r",
+									"    pm.response.to.have.status(401);\r",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\r\n  \"username\": \"kapua-sys\",\r\n  \"password\": \"wrong-password\"\r\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "http://localhost:8081/v1/authentication/user",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "8081",
+							"path": [
+								"v1",
+								"authentication",
+								"user"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Login with wrong username and correct password",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "b89edcba-14b3-4bb1-93b9-045ec4ac8921",
+								"exec": [
+									"pm.test(\"Status code is 401\", function () {\r",
+									"    pm.response.to.have.status(401);\r",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\r\n  \"username\": \"kapua-username\",\r\n  \"password\": \"kapua-password\"\r\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "http://localhost:8081/v1/authentication/user",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "8081",
+							"path": [
+								"v1",
+								"authentication",
+								"user"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Login with empty username and correct password",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "80d32002-659c-4144-ac6d-914631acd9b7",
+								"exec": [
+									"pm.test(\"Status code is 500\", function () {\r",
+									"    pm.response.to.have.status(500);\r",
+									"});\r",
+									"pm.test(\"Body matches string\", function () {\r",
+									"    pm.expect(pm.response.text()).to.include(\"type\");\r",
+									"    pm.expect(pm.response.text()).to.include(\"httpErrorCode\");\r",
+									"    pm.expect(pm.response.text()).to.include(\"message\");\r",
+									"    pm.expect(pm.response.text()).to.include(\"kapuaErrorCode\");\r",
+									"});\r",
+									"\r",
+									"var jsonData = pm.response.json(); \r",
+									"\r",
+									"    pm.test(\"Verify type\", function () { \r",
+									"        pm.expect(jsonData.type).is.to.equal(\"exceptionInfo\"); \r",
+									"    });\r",
+									"\r",
+									"    pm.test(\"Verify httpErrorCode\", function () { \r",
+									"        pm.expect(jsonData.httpErrorCode).is.to.equal(500); \r",
+									"    });\r",
+									"\r",
+									"    pm.test(\"Verify message\", function () { \r",
+									"        pm.expect(jsonData.message).is.to.equal(\"An internal error occurred: org.apache.shiro.ShiroException: Error while find user!.\"); \r",
+									"    });\r",
+									"\r",
+									"    pm.test(\"Verify kapuaErrorCode\", function () { \r",
+									"        pm.expect(jsonData.kapuaErrorCode).is.to.equal(\"INTERNAL_ERROR\"); \r",
+									"    });"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\r\n  \"username\": \"\",\r\n  \"password\": \"kapua-password\"\r\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "http://localhost:8081/v1/authentication/user",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "8081",
+							"path": [
+								"v1",
+								"authentication",
+								"user"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Login with correct username and empty password",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "f6f16bc6-eab4-45f3-a6e9-f2e5cc33dd90",
+								"exec": [
+									"pm.test(\"Status code is 401\", function () {\r",
+									"    pm.response.to.have.status(401);\r",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\r\n  \"username\": \"kapua-sys\",\r\n  \"password\": \"\"\r\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "http://localhost:8081/v1/authentication/user",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "8081",
+							"path": [
+								"v1",
+								"authentication",
+								"user"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Login with empty username and password",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "4efd4479-6b9a-4e0e-a531-959bb59d78d6",
+								"exec": [
+									"pm.test(\"Status code is 500\", function () {\r",
+									"    pm.response.to.have.status(500);\r",
+									"});\r",
+									"pm.test(\"Body matches string\", function () {\r",
+									"    pm.expect(pm.response.text()).to.include(\"type\");\r",
+									"    pm.expect(pm.response.text()).to.include(\"httpErrorCode\");\r",
+									"    pm.expect(pm.response.text()).to.include(\"message\");\r",
+									"    pm.expect(pm.response.text()).to.include(\"kapuaErrorCode\");\r",
+									"});\r",
+									"\r",
+									"var jsonData = pm.response.json(); \r",
+									"\r",
+									"    pm.test(\"Verify type\", function () { \r",
+									"        pm.expect(jsonData.type).is.to.equal(\"exceptionInfo\"); \r",
+									"    });\r",
+									"\r",
+									"    pm.test(\"Verify httpErrorCode\", function () { \r",
+									"        pm.expect(jsonData.httpErrorCode).is.to.equal(500); \r",
+									"    });\r",
+									"\r",
+									"    pm.test(\"Verify message\", function () { \r",
+									"        pm.expect(jsonData.message).is.to.equal(\"An internal error occurred: org.apache.shiro.ShiroException: Error while find user!.\"); \r",
+									"    });\r",
+									"\r",
+									"    pm.test(\"Verify kapuaErrorCode\", function () { \r",
+									"        pm.expect(jsonData.kapuaErrorCode).is.to.equal(\"INTERNAL_ERROR\"); \r",
+									"    });"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\r\n  \"username\": \"\",\r\n  \"password\": \"\"\r\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "http://localhost:8081/v1/authentication/user",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "8081",
+							"path": [
+								"v1",
+								"authentication",
+								"user"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Logout",
+					"request": {
+						"auth": {
+							"type": "bearer",
+							"bearer": [
+								{
+									"key": "token",
+									"value": "{{jwttoken}}",
+									"type": "string"
+								}
+							]
+						},
+						"method": "POST",
+						"header": [],
+						"url": {
+							"raw": "http://localhost:8081/v1/authentication/logout",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "8081",
+							"path": [
+								"v1",
+								"authentication",
+								"logout"
+							]
+						}
+					},
+					"response": []
+				}
+			],
+			"auth": {
+				"type": "noauth"
+			},
+			"event": [
+				{
+					"listen": "prerequest",
+					"script": {
+						"id": "95f728bc-5cd2-4dff-ab74-1d9c3a947514",
+						"type": "text/javascript",
+						"exec": [
+							""
+						]
+					}
+				},
+				{
+					"listen": "test",
+					"script": {
+						"id": "a443a496-b4fe-4ee4-a1d9-267fe349e248",
+						"type": "text/javascript",
+						"exec": [
+							""
+						]
+					}
+				}
+			],
+			"protocolProfileBehavior": {}
+		},
+		{
+			"name": "Creating a group",
+			"item": [
+				{
+					"name": "Unique name without desciption",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "a65518c2-94a5-442b-8e28-9cf27fb0cc9e",
+								"exec": [
+									"pm.test(\"Status code is 201 A group has been created.\", function () {\r",
+									"    pm.response.to.have.status(201);\r",
+									"});\r",
+									"\r",
+									"pm.test(\"Body matches string\", function () {\r",
+									"    pm.expect(pm.response.text()).to.include(\"id\");\r",
+									"    pm.expect(pm.response.text()).to.include(\"scopeId\");\r",
+									"    pm.expect(pm.response.text()).to.include(\"createdOn\");\r",
+									"    pm.expect(pm.response.text()).to.include(\"createdBy\");\r",
+									"    pm.expect(pm.response.text()).to.include(\"modifiedOn\");\r",
+									"    pm.expect(pm.response.text()).to.include(\"modifiedBy\");\r",
+									"    pm.expect(pm.response.text()).to.include(\"optlock\");\r",
+									"    pm.expect(pm.response.text()).to.include(\"name\");\r",
+									"    pm.expect(pm.response.text()).to.include(\"description\");\r",
+									"});\r",
+									""
+								],
+								"type": "text/javascript"
+							}
+						},
+						{
+							"listen": "prerequest",
+							"script": {
+								"id": "92cc524c-70d2-47d8-963b-a8589692d1e0",
+								"exec": [
+									"var username = \"kapua-sys\"",
+									"var password = \"kapua-password\"",
+									"var sdk = require('postman-collection');",
+									"var isValidTokenRequest = new sdk.Request({",
+									"    ",
+									"    url: \"http://localhost:8081/v1/_/groups\",",
+									"    ",
+									"    method: 'GET',",
+									"    header: [",
+									"        new sdk.Header({",
+									"            key: 'content-type',",
+									"            value: 'application/json',",
+									"        }),",
+									"        new sdk.Header({",
+									"            key: 'acccept',",
+									"            value: 'application/json',",
+									"        }),",
+									"        new sdk.Header({",
+									"            key: 'Authorization',",
+									"            value: 'Bearer ' + pm.globals.get(\"jwttoken\"),",
+									"        }),",
+									"    ]",
+									"})",
+									"",
+									"pm.sendRequest(isValidTokenRequest, function (err, response) {",
+									"    if (response.code === 401) {",
+									"        console.log(\"Refreshing token...\");",
+									"        refreshToken();",
+									"    }",
+									"});",
+									"",
+									"function refreshToken() {",
+									"    var tokenRequest = new sdk.Request({",
+									"    url: \"http://localhost:8081/v1/authentication/user\",",
+									"    method: 'POST',",
+									"    header: [",
+									"        new sdk.Header({",
+									"            key: 'content-type',",
+									"            value: 'application/json'",
+									"        }),",
+									"        new sdk.Header({",
+									"            key: 'acccept',",
+									"            value: 'application/json'",
+									"        }),",
+									"    ],",
+									"    body: {",
+									"        mode: 'raw',",
+									"        raw: JSON.stringify({",
+									"            username: username,",
+									"            password: password",
+									"        })",
+									"    } ",
+									"  });",
+									"",
+									"  pm.sendRequest(tokenRequest, function (err, response) {",
+									"      if (err) {",
+									"          throw err;",
+									"      }",
+									"      ",
+									"      if (response.code !== 200) {",
+									"          throw new Error('Could not log in.');",
+									"      }",
+									"      ",
+									"      pm.globals.set(\"jwttoken\", response.json().tokenId);",
+									"      console.log(`New token has been set: ${response.json().tokenId}`);",
+									"  });",
+									"}"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"auth": {
+							"type": "bearer",
+							"bearer": [
+								{
+									"key": "token",
+									"value": "{{jwttoken}}",
+									"type": "string"
+								}
+							]
+						},
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\r\n  \"name\": \"groupName123\",\r\n  \"description\": \"\"\r\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "http://localhost:8081/v1/_/groups",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "8081",
+							"path": [
+								"v1",
+								"_",
+								"groups"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Non-unique name without description",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "c8384d9a-5388-46b0-96ff-a849b778255e",
+								"exec": [
+									"pm.test(\"Status code is 500. An entity with the same name already exists.\", function () {\r",
+									"    pm.response.to.have.status(500);\r",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						},
+						{
+							"listen": "prerequest",
+							"script": {
+								"id": "c3b1f559-5359-4965-8c7f-9fbc1604671d",
+								"exec": [
+									"var username = \"kapua-sys\"",
+									"var password = \"kapua-password\"",
+									"var sdk = require('postman-collection');",
+									"var isValidTokenRequest = new sdk.Request({",
+									"    ",
+									"    url: \"http://localhost:8081/v1/_/groups\",",
+									"    ",
+									"    method: 'GET',",
+									"    header: [",
+									"        new sdk.Header({",
+									"            key: 'content-type',",
+									"            value: 'application/json',",
+									"        }),",
+									"        new sdk.Header({",
+									"            key: 'acccept',",
+									"            value: 'application/json',",
+									"        }),",
+									"        new sdk.Header({",
+									"            key: 'Authorization',",
+									"            value: 'Bearer ' + pm.globals.get(\"jwttoken\"),",
+									"        }),",
+									"    ]",
+									"})",
+									"",
+									"pm.sendRequest(isValidTokenRequest, function (err, response) {",
+									"    if (response.code === 401) {",
+									"        console.log(\"Refreshing token...\");",
+									"        refreshToken();",
+									"    }",
+									"});",
+									"",
+									"function refreshToken() {",
+									"    var tokenRequest = new sdk.Request({",
+									"    url: \"http://localhost:8081/v1/authentication/user\",",
+									"    method: 'POST',",
+									"    header: [",
+									"        new sdk.Header({",
+									"            key: 'content-type',",
+									"            value: 'application/json'",
+									"        }),",
+									"        new sdk.Header({",
+									"            key: 'acccept',",
+									"            value: 'application/json'",
+									"        }),",
+									"    ],",
+									"    body: {",
+									"        mode: 'raw',",
+									"        raw: JSON.stringify({",
+									"            username: username,",
+									"            password: password",
+									"        })",
+									"    } ",
+									"  });",
+									"",
+									"  pm.sendRequest(tokenRequest, function (err, response) {",
+									"      if (err) {",
+									"          throw err;",
+									"      }",
+									"      ",
+									"      if (response.code !== 200) {",
+									"          throw new Error('Could not log in.');",
+									"      }",
+									"      ",
+									"      pm.globals.set(\"jwttoken\", response.json().tokenId);",
+									"      console.log(`New token has been set: ${response.json().tokenId}`);",
+									"  });",
+									"}"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"auth": {
+							"type": "bearer",
+							"bearer": [
+								{
+									"key": "token",
+									"value": "{{jwttoken}}",
+									"type": "string"
+								}
+							]
+						},
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\r\n    \"name\": \"groupName123\",\r\n    \"description\": \"\"\r\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "http://localhost:8081/v1/_/groups",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "8081",
+							"path": [
+								"v1",
+								"_",
+								"groups"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Without name and description",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "10b5d4d4-c40a-497c-9650-699ffd4827dd",
+								"exec": [
+									"pm.test(\"Status code is 400. An illegal null value was provided for the argument groupCreator.name.\", function () {\r",
+									"    pm.response.to.have.status(400);\r",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						},
+						{
+							"listen": "prerequest",
+							"script": {
+								"id": "acd586c2-1d98-43f4-9323-2ed0a0d8cd97",
+								"exec": [
+									"var username = \"kapua-sys\"",
+									"var password = \"kapua-password\"",
+									"var sdk = require('postman-collection');",
+									"var isValidTokenRequest = new sdk.Request({",
+									"    ",
+									"    url: \"http://localhost:8081/v1/_/groups\", ",
+									"    ",
+									"    method: 'GET',",
+									"    header: [",
+									"        new sdk.Header({",
+									"            key: 'content-type',",
+									"            value: 'application/json',",
+									"        }),",
+									"        new sdk.Header({",
+									"            key: 'acccept',",
+									"            value: 'application/json',",
+									"        }),",
+									"        new sdk.Header({",
+									"            key: 'Authorization',",
+									"            value: 'Bearer ' + pm.globals.get(\"jwttoken\"),",
+									"        }),",
+									"    ]",
+									"})",
+									"",
+									"pm.sendRequest(isValidTokenRequest, function (err, response) {",
+									"    if (response.code === 401) {",
+									"        console.log(\"Refreshing token...\");",
+									"        refreshToken();",
+									"    }",
+									"});",
+									"",
+									"function refreshToken() {",
+									"    var tokenRequest = new sdk.Request({",
+									"    url: \"http://localhost:8081/v1/authentication/user\",",
+									"    method: 'POST',",
+									"    header: [",
+									"        new sdk.Header({",
+									"            key: 'content-type',",
+									"            value: 'application/json'",
+									"        }),",
+									"        new sdk.Header({",
+									"            key: 'acccept',",
+									"            value: 'application/json'",
+									"        }),",
+									"    ],",
+									"    body: {",
+									"        mode: 'raw',",
+									"        raw: JSON.stringify({",
+									"            username: username,",
+									"            password: password",
+									"        })",
+									"    } ",
+									"  });",
+									"",
+									"  pm.sendRequest(tokenRequest, function (err, response) {",
+									"      if (err) {",
+									"          throw err;",
+									"      }",
+									"      ",
+									"      if (response.code !== 200) {",
+									"          throw new Error('Could not log in.');",
+									"      }",
+									"      ",
+									"      pm.globals.set(\"jwttoken\", response.json().tokenId);",
+									"      console.log(`New token has been set: ${response.json().tokenId}`);",
+									"  });",
+									"}"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"auth": {
+							"type": "bearer",
+							"bearer": [
+								{
+									"key": "token",
+									"value": "{{jwttoken}}",
+									"type": "string"
+								}
+							]
+						},
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\r\n    \"name\": \"\",\r\n    \"description\": \"\"\r\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "http://localhost:8081/v1/_/groups",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "8081",
+							"path": [
+								"v1",
+								"_",
+								"groups"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Short name without description",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "57ddee1c-b1db-40fc-8843-04132668d2f4",
+								"exec": [
+									"pm.test(\"Status code is 201. A group has been created.\", function () {\r",
+									"    pm.response.to.have.status(201);\r",
+									"});\r",
+									"\r",
+									"pm.test(\"Body matches string\", function () {\r",
+									"    pm.expect(pm.response.text()).to.include(\"id\");\r",
+									"    pm.expect(pm.response.text()).to.include(\"scopeId\");\r",
+									"    pm.expect(pm.response.text()).to.include(\"createdOn\");\r",
+									"    pm.expect(pm.response.text()).to.include(\"createdBy\");\r",
+									"    pm.expect(pm.response.text()).to.include(\"modifiedOn\");\r",
+									"    pm.expect(pm.response.text()).to.include(\"modifiedBy\");\r",
+									"    pm.expect(pm.response.text()).to.include(\"optlock\");\r",
+									"    pm.expect(pm.response.text()).to.include(\"name\");\r",
+									"    pm.expect(pm.response.text()).to.include(\"description\");\r",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						},
+						{
+							"listen": "prerequest",
+							"script": {
+								"id": "0474229a-b5a1-44db-ab27-17d07a1745dc",
+								"exec": [
+									"var username = \"kapua-sys\"",
+									"var password = \"kapua-password\"",
+									"var sdk = require('postman-collection');",
+									"var isValidTokenRequest = new sdk.Request({",
+									"    ",
+									"    url: \"http://localhost:8081/v1/_/groups\",",
+									"    ",
+									"    method: 'GET',",
+									"    header: [",
+									"        new sdk.Header({",
+									"            key: 'content-type',",
+									"            value: 'application/json',",
+									"        }),",
+									"        new sdk.Header({",
+									"            key: 'acccept',",
+									"            value: 'application/json',",
+									"        }),",
+									"        new sdk.Header({",
+									"            key: 'Authorization',",
+									"            value: 'Bearer ' + pm.globals.get(\"jwttoken\"),",
+									"        }),",
+									"    ]",
+									"})",
+									"",
+									"pm.sendRequest(isValidTokenRequest, function (err, response) {",
+									"    if (response.code === 401) {",
+									"        console.log(\"Refreshing token...\");",
+									"        refreshToken();",
+									"    }",
+									"});",
+									"",
+									"function refreshToken() {",
+									"    var tokenRequest = new sdk.Request({",
+									"    url: \"http://localhost:8081/v1/authentication/user\",",
+									"    method: 'POST',",
+									"    header: [",
+									"        new sdk.Header({",
+									"            key: 'content-type',",
+									"            value: 'application/json'",
+									"        }),",
+									"        new sdk.Header({",
+									"            key: 'acccept',",
+									"            value: 'application/json'",
+									"        }),",
+									"    ],",
+									"    body: {",
+									"        mode: 'raw',",
+									"        raw: JSON.stringify({",
+									"            username: username,",
+									"            password: password",
+									"        })",
+									"    } ",
+									"  });",
+									"",
+									"  pm.sendRequest(tokenRequest, function (err, response) {",
+									"      if (err) {",
+									"          throw err;",
+									"      }",
+									"      ",
+									"      if (response.code !== 200) {",
+									"          throw new Error('Could not log in.');",
+									"      }",
+									"      ",
+									"      pm.globals.set(\"jwttoken\", response.json().tokenId);",
+									"      console.log(`New token has been set: ${response.json().tokenId}`);",
+									"  });",
+									"}"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"auth": {
+							"type": "bearer",
+							"bearer": [
+								{
+									"key": "token",
+									"value": "{{jwttoken}}",
+									"type": "string"
+								}
+							]
+						},
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\r\n    \"name\": \"aec\",\r\n    \"description\": \"\"\r\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "http://localhost:8081/v1/_/groups",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "8081",
+							"path": [
+								"v1",
+								"_",
+								"groups"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Too short name without description",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "7021a96f-b502-4c3f-891c-54e672de07aa",
+								"exec": [
+									"pm.test(\"Status code is 400. An illegal value was provided for the argument groupCreator.name: Value less than allowed min length. Min length is 3.\", function () {\r",
+									"    pm.response.to.have.status(400);\r",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						},
+						{
+							"listen": "prerequest",
+							"script": {
+								"id": "31160999-c459-4724-b655-9236c86ed4a4",
+								"exec": [
+									"var username = \"kapua-sys\"",
+									"var password = \"kapua-password\"",
+									"var sdk = require('postman-collection');",
+									"var isValidTokenRequest = new sdk.Request({",
+									"    ",
+									"    url: \"http://localhost:8081/v1/_/groups\", ",
+									"    ",
+									"    method: 'GET',",
+									"    header: [",
+									"        new sdk.Header({",
+									"            key: 'content-type',",
+									"            value: 'application/json',",
+									"        }),",
+									"        new sdk.Header({",
+									"            key: 'acccept',",
+									"            value: 'application/json',",
+									"        }),",
+									"        new sdk.Header({",
+									"            key: 'Authorization',",
+									"            value: 'Bearer ' + pm.globals.get(\"jwttoken\"),",
+									"        }),",
+									"    ]",
+									"})",
+									"",
+									"pm.sendRequest(isValidTokenRequest, function (err, response) {",
+									"    if (response.code === 401) {",
+									"        console.log(\"Refreshing token...\");",
+									"        refreshToken();",
+									"    }",
+									"});",
+									"",
+									"function refreshToken() {",
+									"    var tokenRequest = new sdk.Request({",
+									"    url: \"http://localhost:8081/v1/authentication/user\",",
+									"    method: 'POST',",
+									"    header: [",
+									"        new sdk.Header({",
+									"            key: 'content-type',",
+									"            value: 'application/json'",
+									"        }),",
+									"        new sdk.Header({",
+									"            key: 'acccept',",
+									"            value: 'application/json'",
+									"        }),",
+									"    ],",
+									"    body: {",
+									"        mode: 'raw',",
+									"        raw: JSON.stringify({",
+									"            username: username,",
+									"            password: password",
+									"        })",
+									"    } ",
+									"  });",
+									"",
+									"  pm.sendRequest(tokenRequest, function (err, response) {",
+									"      if (err) {",
+									"          throw err;",
+									"      }",
+									"      ",
+									"      if (response.code !== 200) {",
+									"          throw new Error('Could not log in.');",
+									"      }",
+									"      ",
+									"      pm.globals.set(\"jwttoken\", response.json().tokenId);",
+									"      console.log(`New token has been set: ${response.json().tokenId}`);",
+									"  });",
+									"}"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"auth": {
+							"type": "bearer",
+							"bearer": [
+								{
+									"key": "token",
+									"value": "{{jwttoken}}",
+									"type": "string"
+								}
+							]
+						},
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\r\n    \"name\": \"a\",\r\n    \"description\": \"\"\r\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "http://localhost:8081/v1/_/groups",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "8081",
+							"path": [
+								"v1",
+								"_",
+								"groups"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Get all groups",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "c8d4d530-33e2-47a4-b08a-882d4737aacc",
+								"exec": [
+									"pm.test(\"Status code is 200\", function () {\r",
+									"    pm.response.to.have.status(200);\r",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						},
+						{
+							"listen": "prerequest",
+							"script": {
+								"id": "58430d0f-b7c1-4a7e-8698-61f688b008a7",
+								"exec": [
+									"var username = \"kapua-sys\"",
+									"var password = \"kapua-password\"",
+									"var sdk = require('postman-collection');",
+									"var isValidTokenRequest = new sdk.Request({",
+									"    ",
+									"    url: \"http://localhost:8081/v1/_/groups\", ",
+									"    ",
+									"    method: 'GET',",
+									"    header: [",
+									"        new sdk.Header({",
+									"            key: 'content-type',",
+									"            value: 'application/json',",
+									"        }),",
+									"        new sdk.Header({",
+									"            key: 'acccept',",
+									"            value: 'application/json',",
+									"        }),",
+									"        new sdk.Header({",
+									"            key: 'Authorization',",
+									"            value: 'Bearer ' + pm.globals.get(\"jwttoken\"),",
+									"        }),",
+									"    ]",
+									"})",
+									"",
+									"pm.sendRequest(isValidTokenRequest, function (err, response) {",
+									"    if (response.code === 401) {",
+									"        console.log(\"Refreshing token...\");",
+									"        refreshToken();",
+									"    }",
+									"});",
+									"",
+									"function refreshToken() {",
+									"    var tokenRequest = new sdk.Request({",
+									"    url: \"http://localhost:8081/v1/authentication/user\",",
+									"    method: 'POST',",
+									"    header: [",
+									"        new sdk.Header({",
+									"            key: 'content-type',",
+									"            value: 'application/json'",
+									"        }),",
+									"        new sdk.Header({",
+									"            key: 'acccept',",
+									"            value: 'application/json'",
+									"        }),",
+									"    ],",
+									"    body: {",
+									"        mode: 'raw',",
+									"        raw: JSON.stringify({",
+									"            username: username,",
+									"            password: password",
+									"        })",
+									"    } ",
+									"  });",
+									"",
+									"  pm.sendRequest(tokenRequest, function (err, response) {",
+									"      if (err) {",
+									"          throw err;",
+									"      }",
+									"      ",
+									"      if (response.code !== 200) {",
+									"          throw new Error('Could not log in.');",
+									"      }",
+									"      ",
+									"      pm.globals.set(\"jwttoken\", response.json().tokenId);",
+									"      console.log(`New token has been set: ${response.json().tokenId}`);",
+									"  });",
+									"}"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"auth": {
+							"type": "bearer",
+							"bearer": [
+								{
+									"key": "token",
+									"value": "{{jwttoken}}",
+									"type": "string"
+								}
+							]
+						},
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "http://localhost:8081/v1/_/groups?limit=50&offset=0",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "8081",
+							"path": [
+								"v1",
+								"_",
+								"groups"
+							],
+							"query": [
+								{
+									"key": "limit",
+									"value": "50"
+								},
+								{
+									"key": "offset",
+									"value": "0"
+								}
+							]
+						}
+					},
+					"response": []
+				}
+			],
+			"protocolProfileBehavior": {}
+		}
+	],
+	"auth": {
+		"type": "bearer",
+		"bearer": [
+			{
+				"key": "token",
+				"value": "eyJhbGciOiJSUzI1NiJ9.eyJpc3MiOiJodHRwczovL3d3dy5lY2xpcHNlLm9yZy9rYXB1YSIsImlhdCI6MTU5NDIxMjgzMSwiZXhwIjoxNTk0MjE0NjMxLCJzdWIiOiJBUSIsInNJZCI6IkFRIn0.fre_rsuvan7MqPo1sAfcGxR9sxVCedT_KPi-sm2VijunOItXNSDVFW1dtzGHzyIZwWyXk6LxuV5YS5eVfKfDyz_HrNBfN-w4Mt-cMV4uSTyDPMRLzqCCavKwd_Un8P14h1PmJ0VkqX45xAdkOlxNUydbofkfZkY9vCnvYfppjfJHR4TdfE4zeTOKsa1CbyIH6_b1SE06ke8TPZfTqIGQIP8LyGpIACn80tBSoIVLJgpB5-XBOydx5e0T4ejZej9Cp9ajweOewSJUUoEqw4WGq0duHz76MLbmT4GsGB1wU31O_uVpNIzEtyjk7w2KepZXf2bO9xpNcrYYhg8kK9orPIyfTu2uvontBingZQkskToGPv4aWA5V2GxpBstvHqgzGfbV9IgZe6O4GWJqGYZtWrMBzwX-MdnjZfnVZgriONdpCPL7iUu6fS3rEV_K9iSl6H_PXm4127ErZyupIsUqjOK13PrYYqRHtLJdMM4JJVS2UsWpXRAzw29Dvdbnyh97EtftU2CYOXMttoGTw_0IdbilkedF1unYaOQqmjnxBaM3-nCH6aYhvEWT4TAbGPLzbRm9UaMgXa2h1PN-Urg89gZKJf3RBcjZaOAJo3yetrX-EZiENkTr6jVfDG6FPN8bnC9dPthWvzCh7R8qXNZKLXYlPXMXCfDVcF8s6huEGWE",
+				"type": "string"
+			}
+		]
+	},
+	"event": [
+		{
+			"listen": "prerequest",
+			"script": {
+				"id": "644908d8-421f-4c66-9726-76a151522bab",
+				"type": "text/javascript",
+				"exec": [
+					""
+				]
+			}
+		},
+		{
+			"listen": "test",
+			"script": {
+				"id": "42ae9b46-d55f-4da8-9f20-8bd80a9ea366",
+				"type": "text/javascript",
+				"exec": [
+					""
+				]
+			}
+		}
+	],
+	"protocolProfileBehavior": {}
+}

--- a/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/token/AccessTokenAttributes.java
+++ b/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/token/AccessTokenAttributes.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -22,5 +22,7 @@ public class AccessTokenAttributes extends KapuaUpdatableEntityAttributes {
 
     public static final String TOKEN_ID = "tokenId";
     public static final String USER_ID = "userId";
+    public static final String EXPIRES_ON = "expiresOn";
+    public static final String INVALIDATED_ON = "invalidatedOn";
 
 }

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/realm/AccessTokenAuthenticatingRealm.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/realm/AccessTokenAuthenticatingRealm.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -11,6 +11,8 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.authentication.shiro.realm;
 
+import java.util.Date;
+
 import org.apache.shiro.SecurityUtils;
 import org.apache.shiro.ShiroException;
 import org.apache.shiro.authc.AuthenticationException;
@@ -21,22 +23,26 @@ import org.apache.shiro.authc.ExpiredCredentialsException;
 import org.apache.shiro.authc.UnknownAccountException;
 import org.apache.shiro.realm.AuthenticatingRealm;
 import org.apache.shiro.subject.Subject;
+
 import org.eclipse.kapua.KapuaException;
 import org.eclipse.kapua.commons.security.KapuaSecurityUtils;
 import org.eclipse.kapua.commons.security.KapuaSession;
 import org.eclipse.kapua.locator.KapuaLocator;
+import org.eclipse.kapua.model.query.predicate.AndPredicate;
+import org.eclipse.kapua.model.query.predicate.AttributePredicate.Operator;
 import org.eclipse.kapua.service.account.Account;
 import org.eclipse.kapua.service.account.AccountService;
 import org.eclipse.kapua.service.authentication.AccessTokenCredentials;
 import org.eclipse.kapua.service.authentication.shiro.AccessTokenCredentialsImpl;
 import org.eclipse.kapua.service.authentication.shiro.exceptions.ExpiredAccountException;
 import org.eclipse.kapua.service.authentication.token.AccessToken;
+import org.eclipse.kapua.service.authentication.token.AccessTokenAttributes;
+import org.eclipse.kapua.service.authentication.token.AccessTokenFactory;
+import org.eclipse.kapua.service.authentication.token.AccessTokenQuery;
 import org.eclipse.kapua.service.authentication.token.AccessTokenService;
 import org.eclipse.kapua.service.user.User;
 import org.eclipse.kapua.service.user.UserService;
 import org.eclipse.kapua.service.user.UserStatus;
-
-import java.util.Date;
 
 /**
  * {@link AccessTokenCredentials} based {@link AuthenticatingRealm} implementation.
@@ -53,6 +59,7 @@ public class AccessTokenAuthenticatingRealm extends AuthenticatingRealm {
     private static final KapuaLocator LOCATOR = KapuaLocator.getInstance();
 
     private static final AccessTokenService ACCESS_TOKEN_SERVICE = LOCATOR.getService(AccessTokenService.class);
+    private static final AccessTokenFactory ACCESS_TOKEN_FACTORY = LOCATOR.getFactory(AccessTokenFactory.class);
     private static final AccountService ACCOUNT_SERVICE = LOCATOR.getService(AccountService.class);
     private static final UserService USER_SERVICE = LOCATOR.getService(UserService.class);
 
@@ -76,11 +83,20 @@ public class AccessTokenAuthenticatingRealm extends AuthenticatingRealm {
         AccessTokenCredentialsImpl token = (AccessTokenCredentialsImpl) authenticationToken;
         String tokenTokenId = token.getTokenId();
 
+        Date now = new Date();
         //
         // Find accessToken
         final AccessToken accessToken;
         try {
-            accessToken = KapuaSecurityUtils.doPrivileged(() -> ACCESS_TOKEN_SERVICE.findByTokenId(tokenTokenId));
+            AccessTokenQuery accessTokenQuery = ACCESS_TOKEN_FACTORY.newQuery(null);
+            AndPredicate andPredicate = accessTokenQuery.andPredicate(
+                    accessTokenQuery.attributePredicate(AccessTokenAttributes.EXPIRES_ON, new java.sql.Timestamp(now.getTime()), Operator.GREATER_THAN_OR_EQUAL),
+                    accessTokenQuery.attributePredicate(AccessTokenAttributes.INVALIDATED_ON, null, Operator.IS_NULL),
+                    accessTokenQuery.attributePredicate(AccessTokenAttributes.TOKEN_ID, tokenTokenId)
+            );
+            accessTokenQuery.setPredicate(andPredicate);
+            accessTokenQuery.setLimit(1);
+            accessToken = KapuaSecurityUtils.doPrivileged(() -> ACCESS_TOKEN_SERVICE.query(accessTokenQuery).getFirstItem());
         } catch (AuthenticationException ae) {
             throw ae;
         } catch (Exception e) {
@@ -93,8 +109,8 @@ public class AccessTokenAuthenticatingRealm extends AuthenticatingRealm {
         }
 
         // Check validity
-        if ((accessToken.getExpiresOn() != null && accessToken.getExpiresOn().before(new Date())) ||
-                (accessToken.getInvalidatedOn() != null && accessToken.getInvalidatedOn().before(new Date()))) {
+        if ((accessToken.getExpiresOn() != null && accessToken.getExpiresOn().before(now)) ||
+                (accessToken.getInvalidatedOn() != null && accessToken.getInvalidatedOn().before(now))) {
             throw new ExpiredCredentialsException();
         }
 
@@ -120,7 +136,7 @@ public class AccessTokenAuthenticatingRealm extends AuthenticatingRealm {
         }
 
         // Check if expired
-        if (user.getExpirationDate() != null && !user.getExpirationDate().after(new Date())) {
+        if (user.getExpirationDate() != null && !user.getExpirationDate().after(now)) {
             throw new ExpiredCredentialsException();
         }
 
@@ -141,7 +157,7 @@ public class AccessTokenAuthenticatingRealm extends AuthenticatingRealm {
         }
 
         // Check account expired
-        if (account.getExpirationDate() != null && !account.getExpirationDate().after(new Date())) {
+        if (account.getExpirationDate() != null && !account.getExpirationDate().after(now)) {
             throw new ExpiredAccountException(account.getExpirationDate());
         }
 

--- a/service/security/shiro/src/main/resources/liquibase/1.3.0/atht-access_token-expires_index.xml
+++ b/service/security/shiro/src/main/resources/liquibase/1.3.0/atht-access_token-expires_index.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2020 Eurotech and/or its affiliates and others
+
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+
+    Contributors:
+        Eurotech - initial API and implementation
+ -->
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd"
+        logicalFilePath="KapuaDB/atht-access_token-expires_index.xml">
+
+    <changeSet id="changelog-access_token-1.3.0_expires_index" author="eurotech">
+        <createIndex tableName="atht_access_token" indexName="idx_atht_access_token_expires_on">
+            <column name="expires_on" />
+        </createIndex>
+    </changeSet>
+
+</databaseChangeLog>

--- a/service/security/shiro/src/main/resources/liquibase/1.3.0/changelog-authentication-1.3.0.xml
+++ b/service/security/shiro/src/main/resources/liquibase/1.3.0/changelog-authentication-1.3.0.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2020 Eurotech and/or its affiliates and others
+
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+
+    Contributors:
+        Eurotech - initial API and implementation
+ -->
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd"
+        logicalFilePath="KapuaDB/changelog-authentication-1.3.0.xml">
+
+    <include relativeToChangelogFile="true" file="./atht-access_token-expires_index.xml"/>
+
+</databaseChangeLog>

--- a/service/security/shiro/src/main/resources/liquibase/changelog-authentication-master.xml
+++ b/service/security/shiro/src/main/resources/liquibase/changelog-authentication-master.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
@@ -19,5 +19,6 @@
     <include relativeToChangelogFile="true" file="./0.3.0/changelog-authentication-0.3.0.xml"/>
     <include relativeToChangelogFile="true" file="./1.0.0/changelog-authentication-1.0.0.xml"/>
     <include relativeToChangelogFile="true" file="./1.2.0/changelog-authentication-1.2.0.xml"/>
+    <include relativeToChangelogFile="true" file="./1.3.0/changelog-authentication-1.3.0.xml"/>
 
 </databaseChangeLog>


### PR DESCRIPTION
I have added a "smart" timeout to the docker-deploy.sh script because there were some trobules with running Rest API tests.
The problem is, that once you run this script, docker containers get status "Running" although
they are not properly started just yet - they need a minute or so to properly start.
Without this addition, the Rest API tests will start as soon the docker-deploy.sh scripts completes and
the tests will fail, because API container is not set.
Therefore this timeout checks API container log for a certain string every 5 seconds (when this string
appears the container is up and running), to see if the container is properly running or not.
I have tested this and it works fine.
Second thing is added JSON file with REST API tests in /kapua/rest-api/tests/ folder.
Third thing is upgraded .travis.yml file, that now introduces another stage (REST API test stage).

Signed-off-by: Leonardo Gaube <leonardo.gaube@comtrade.com>
