### PR TITLE
Fixed commands for running tests, updated documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,9 @@
 ![GitHub release (latest by date)](https://img.shields.io/github/v/release/eclipse/kapua)
 ![GitHub contributors](https://img.shields.io/github/contributors/eclipse/kapua)
 ![GitHub forks](https://img.shields.io/github/forks/eclipse/kapua?style=social)
+[![codecov](https://codecov.io/gh/LeoNerdoG/kapua/branch/develop/graph/badge.svg)](https://codecov.io/gh/LeoNerdoG/kapua)
 
-[Eclipse Kapua&trade;](http://eclipse.org/kapua) is a modular platform providing the services required to manage IoT gateways and smart edge devices. Kapua provides a core integration framework and an initial set of core IoT services including a device registry, device management services, messaging services, data management, and application enablement.
+[Eclipse Kapua&trade;](http://eclipse.org/kapua) is a modular platform providing the services required to manage IoT gateways and smart edge devices. Kapua&trade; provides a core integration framework and an initial set of core IoT services including a device registry, device management services, messaging services, data management, and application enablement.
 
 
 ## Quick Start Guide
@@ -24,7 +25,7 @@ Eclipse Kapua&trade; runs as distributed application that exposes three basic se
 * The RESTful API
 * The Web Administration Console
 
-Two more backend services are required that implement the data tier:
+Three more backend services are required that implement the data tier:
 * The Event Bus Service
 * The SQL database
 * The NoSQL datastore
@@ -42,10 +43,10 @@ Before starting, check that your environment has the following prerequisites:
 
 ### Demo Setup
 
-The team maintains some docker images in a Docker Hub repository at [Kapua Repository](https://hub.docker.com/r/kapua/). Check the repo to view the list of available images, if you haven't found one fitting your needs you may create your own. Please refer to the paragraph [More deployment info](#more-deployment-info) to find more about creating your own images and/or alternative demo deployment scenarios.
+The team maintains some docker images in a Docker Hub repository at [Kapua&trade; Repository](https://hub.docker.com/r/kapua/). Check the repo to view the list of available images, if you haven't found one fitting your needs you may create your own. Please refer to the paragraph [More deployment info](#more-deployment-info) to find more about creating your own images and/or alternative demo deployment scenarios.
 
 ***
-**Note:** the Docker Hub repository mentioned above is not the official project repository from Eclipse Foundation.
+**Note:** The Docker Hub repository mentioned above is not the official project repository from Eclipse Foundation.
 ***
 
 Suppose the target is the current snapshot 1.3.0-SNAPSHOT.
@@ -67,7 +68,7 @@ On Windows (PowerShell):
     ./deployment/docker/win/docker-deploy.ps1
 ```
 
-The command starts all the Kapua containers using Docker Compose.
+The command starts all the Kapua&trade; containers using Docker Compose.
 
 By default, the `latest` version of images will be used. If you want to run some other version of Kapua, set the `IMAGE_VERSION` environment variable, for example:
 
@@ -81,7 +82,7 @@ You can check if the containers are running by typing the following command:
     docker ps -as
 ```
 
-Docker will list the containers currently running.
+Docker will list all the current running containers.
 
 To stop Kapua, run
 
@@ -99,11 +100,11 @@ On Windows (PowerShell):
 
 ### Access
 
-Once the containers are running, the Kapua services can be accessed. Eclipse Kapua&trade; is a multi tenant
+Once the containers are running, the Kapua&trade; services can be accessed. Eclipse Kapua&trade; is a multi tenant
 system. The demo installation comes with one default tenant, called _kapua-sys_, which is also the root tenant. 
 In Eclipse Kapua&trade; a _tenant_ is commonly referred to as an _account_.
 
-#### The console
+#### The Console
 
 The administration console is available at [http://localhost:8080/](http://localhost:8080/). 
 Copy paste the URL above to a Web browser, as the login screen appears, type the following credentials:
@@ -120,9 +121,9 @@ the IP address of your docker instance.
 
 The documentation of RESTful API is available at [http://localhost:8081/doc/](http://localhost:8081/doc/) while the mount points are available at [http://localhost:8081/v1/](http://localhost:8081/v1/).
 
-The documentation is available through Swagger UI which greatly helps testing and exploring the exposed services.
+The documentation is available through Swagger UI which greatly helps with testing and exploring the exposed services.
 
-In order to get access a REST resource through an API, an authentication token is needed. Fortunately the token can be easily obtained by executing the authentication API. There are several ways to invoke the API, an easy one is by using the Swagger UI:
+In order to get access to REST resource through an API, an authentication token is needed. Fortunately, the token can be easily obtained by executing the authentication API. There are several ways to invoke the API, an easy one is by using the Swagger UI:
 
 * Open the URL http://localhost:8081/doc/
 * Select item _Authentication_
@@ -176,10 +177,10 @@ the IP address of your docker instance.
 
 #### Simulation
 
-Kapua comes with a framework that you can use to simulate Kura gateways. It can be used to test your Kapua deployments easily. See [Simulator documentation](docs/user-manual/en/simulator.md) for more info.
+Kapua&trade; comes with a framework that you can use to simulate Kura gateways. It can be used to test your Kapua deployments easily. See [Simulator documentation](docs/user-manual/en/simulator.md) for more info.
 
-#### More deployment info
-Installing and running a demo using Docker is easy, but it's not the only way. There are other scenarios that the users may be interested in. We provide advanced setup scenarios in the following guides:
+#### More Deployment Info
+Installing and running a demo using Docker is easy, but it's not the only way. There are other scenarios that users may be interested in. We provide advanced setup scenarios in the following guides:
 
 * [Running with Docker](deployment/docker/README.md)
 * [Running with OpenShift](docs/developer-guide/en/running.md#openshift)

--- a/RunTests.md
+++ b/RunTests.md
@@ -1,22 +1,27 @@
-# How to execute Kapua tests
+# How to Execute Kapua Tests
 
-There are couple of ways to run tests, either pure unit tests, component tests or integration tests.
+There are a couple of ways to run tests, either pure unit tests, component tests or integration tests.
 Integration tests can be run:
 
-- using embedded servers
 - using dockerized servers
+- using embedded servers
 
-## With dockerized Kapua
+## With Dockerized Kapua
+
 With fabric8 plugin usage tests can now be run without explicitly running dockerized environment.
 Docker containers providing Kapua infrastructure are started with maven itself.
-But to run these integration tests, you have to switch to qa folder and run following command
+Nevertheless, in order to run these integration tests, you first have to build project from root with command:
+
+    mvn clean install -DskipTests -Pdocker
+    
+and afterwards switch to qa folder and run the following command:
 
     mvn test -PI9nTests
     
-This will run integration tests only, those are tests written in gherkin and being annotated with
+This will run integration tests only, those are tests written in Gherkin and being annotated with
 ``@integration``
 
-If tests fail and dockers are still running use this command:
+If tests fail and Dockers containers are still running, use this command:
 
     mvn docker:stop -PI9nTests
 
@@ -25,16 +30,16 @@ Example response with time:
     [INFO] ------------------------------------------------------------------------
     [INFO] BUILD SUCCESS
     [INFO] ------------------------------------------------------------------------
-    [INFO] Total time: 18:11 min
-    [INFO] Finished at: 2019-03-04T14:16:32+01:00
-    [INFO] Final Memory: 48M/728M
-    [INFO] ------------------------------------------------------------------------    
+    [INFO] Total time: 52:36 min
+    [INFO] Finished at: 2020-11-05T22:24:38+01:00
+    [INFO] Final Memory: 47M/660M
+    [INFO] ------------------------------------------------------------------------  
 
-##Without dockerized Kapua
-By default tests are run with embedded servers providing kapua infrastructure services, such as
-database, event-broker, message broker, elaticsearch.
+## Using Embedded Servers
+By default, tests are run with embedded servers providing Kapua infrastructure services, such as
+database, event-broker, message broker, Elasticsearch.
 
-So to run those use default profile and run:
+To run those use default profile and run:
 
     mvn clean install
     or
@@ -43,7 +48,7 @@ So to run those use default profile and run:
 Those two commands will use following defaults:
 
     cucumber.options="--tags ~@rest"
-    groups='!org.eclipse.kapua.test.junit.JUnitTests'
+    groups='!org.eclipse.kapua.qa.markers.junit.JUnitTests'
     commons.settings.hotswap=true
     commons.db.schema.update=true
     commons.db.schema=kapuadb
@@ -51,6 +56,7 @@ Those two commands will use following defaults:
 
 Example response with time:
 
+    [INFO] ------------------------------------------------------------------------
     [INFO] BUILD SUCCESS
     [INFO] ------------------------------------------------------------------------
     [INFO] Total time: 31:14 min
@@ -58,12 +64,14 @@ Example response with time:
     [INFO] Final Memory: 244M/1761M
     [INFO] ------------------------------------------------------------------------
 
-## Run pure junit tests
+## Running Pure JUnit Tests
+For running pure JUnit tests navigate to root folder and execute the following command:
 
-    mvn test -Dgroups='org.eclipse.kapua.test.junit.JUnitTests'
+    mvn test -Dgroups='org.eclipse.kapua.qa.markers.test.junit.JUnitTests'
 
 Example response with time:
 
+    [INFO] ------------------------------------------------------------------------
     [INFO] BUILD SUCCESS
     [INFO] ------------------------------------------------------------------------
     [INFO] Total time: 05:26 min

--- a/assembly/console/entrypoint/run-console
+++ b/assembly/console/entrypoint/run-console
@@ -33,27 +33,21 @@ if [ -n "$KEYCLOAK_URL" ] && [ -n "$KAPUA_CONSOLE_URL" ]; then
 fi
 
 # Check for generic OpenID Connect provider integration
-if [ -n "$KAPUA_CONSOLE_URL" ] && [ -n "$OPENID_JWT_ISSUER" ] && [ -n "$OPENID_AUTH_ENDPOINT" ] && [ -n "$OPENID_LOGOUT_ENDPOINT" ] && [ -n "$OPENID_TOKEN_ENDPOINT" ]; then
+if [ -n "${KAPUA_CONSOLE_URL}" ] && [ -n "${OPENID_JWT_ISSUER}" ]; then
    echo "Activating OpenID Connect Generic integration..."
-   echo "  Kapua:    $KAPUA_CONSOLE_URL"
-   echo "  OpenID Issuer: $OPENID_JWT_ISSUER"
-   echo "  Auth Endpoint: $OPENID_AUTH_ENDPOINT"
-   echo "  Logout Endpoint: $OPENID_LOGOUT_ENDPOINT"
-   echo "  Token Endpoint: $OPENID_TOKEN_ENDPOINT"
+  echo "  OpenID Issuer: ${OPENID_JWT_ISSUER}"
+  echo "  Console: ${KAPUA_CONSOLE_URL}"
 
-   : OPENID_CLIENT_ID=${OPENID_CLIENT_ID:=console}
-   : JWT_AUDIENCE=${JWT_AUDIENCE:=console}
+  JAVA_OPTS="${JAVA_OPTS} -Dsso.provider=generic"
+  JAVA_OPTS="${JAVA_OPTS} -Dsso.openid.client.id=${OPENID_CLIENT_ID:-console}"
+  test -n "${CLIENT_SECRET}" && JAVA_OPTS="${JAVA_OPTS} -Dsso.openid.client.secret=${CLIENT_SECRET}"
+  JAVA_OPTS="${JAVA_OPTS} -Dconsole.sso.home.uri=${KAPUA_CONSOLE_URL}"
 
-   JAVA_OPTS="$JAVA_OPTS -Dsso.provider=generic"
-   JAVA_OPTS="$JAVA_OPTS -Dsso.openid.client.id=${OPENID_CLIENT_ID}"
-   test -n "$CLIENT_SECRET" && JAVA_OPTS="$JAVA_OPTS -Dsso.openid.client.secret=${CLIENT_SECRET}"
-   JAVA_OPTS="$JAVA_OPTS -Dconsole.sso.home.uri=${KAPUA_CONSOLE_URL}"
-
-   JAVA_OPTS="$JAVA_OPTS -Dsso.generic.openid.jwt.audience.allowed=${JWT_AUDIENCE}"
-   JAVA_OPTS="$JAVA_OPTS -Dsso.generic.openid.jwt.issuer.allowed=${OPENID_JWT_ISSUER}"
-   JAVA_OPTS="$JAVA_OPTS -Dsso.generic.openid.server.endpoint.auth=${OPENID_AUTH_ENDPOINT}"
-   JAVA_OPTS="$JAVA_OPTS -Dsso.generic.openid.server.endpoint.logout=${OPENID_LOGOUT_ENDPOINT}"
-   JAVA_OPTS="$JAVA_OPTS -Dsso.generic.openid.server.endpoint.token=${OPENID_TOKEN_ENDPOINT}"
+  JAVA_OPTS="${JAVA_OPTS} -Dsso.generic.openid.jwt.audience.allowed=${JWT_AUDIENCE:-console}"
+  JAVA_OPTS="${JAVA_OPTS} -Dsso.generic.openid.jwt.issuer.allowed=${OPENID_JWT_ISSUER}"
+  test -n "${OPENID_AUTH_ENDPOINT}" && JAVA_OPTS="${JAVA_OPTS} -Dsso.generic.openid.server.endpoint.auth=${OPENID_AUTH_ENDPOINT}"
+  test -n "${OPENID_LOGOUT_ENDPOINT}" && JAVA_OPTS="${JAVA_OPTS} -Dsso.generic.openid.server.endpoint.logout=${OPENID_LOGOUT_ENDPOINT}"
+  test -n "${OPENID_TOKEN_ENDPOINT}" && JAVA_OPTS="${JAVA_OPTS} -Dsso.generic.openid.server.endpoint.token=${OPENID_TOKEN_ENDPOINT}"
 fi
 
 # Multi Factor Authentication configurations

--- a/qa/common/pom.xml
+++ b/qa/common/pom.xml
@@ -20,7 +20,22 @@
         <version>1.3.0-SNAPSHOT</version>
     </parent>
 
+    <packaging>pom</packaging>
     <artifactId>kapua-qa-common</artifactId>
+
+    <!-- This is required to skip docker container creation in the module, because it's
+already done in the parent module. -->
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>io.fabric8</groupId>
+                <artifactId>docker-maven-plugin</artifactId>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 
     <dependencies>
         <!-- -->

--- a/qa/integration-steps/pom.xml
+++ b/qa/integration-steps/pom.xml
@@ -20,7 +20,22 @@
         <version>1.3.0-SNAPSHOT</version>
     </parent>
 
+    <packaging>pom</packaging>
     <artifactId>kapua-qa-integration-steps</artifactId>
+
+    <!-- This is required to skip docker container creation in the module, because it's
+already done in the parent module. -->
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>io.fabric8</groupId>
+                <artifactId>docker-maven-plugin</artifactId>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 
     <dependencies>
         <dependency>

--- a/qa/integration/pom.xml
+++ b/qa/integration/pom.xml
@@ -20,7 +20,22 @@
         <version>1.3.0-SNAPSHOT</version>
     </parent>
 
+    <packaging>pom</packaging>
     <artifactId>kapua-qa-integration</artifactId>
+
+    <!-- This is required to skip docker container creation in the module, because it's
+already done in the parent module. -->
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>io.fabric8</groupId>
+                <artifactId>docker-maven-plugin</artifactId>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 
     <dependencies>
         <!-- Required service interfaces -->

--- a/qa/markers/pom.xml
+++ b/qa/markers/pom.xml
@@ -19,7 +19,22 @@
         <version>1.3.0-SNAPSHOT</version>
     </parent>
 
+    <packaging>pom</packaging>
     <artifactId>kapua-qa-markers</artifactId>
+
+    <!-- This is required to skip docker container creation in the module, because it's
+already done in the parent module. -->
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>io.fabric8</groupId>
+                <artifactId>docker-maven-plugin</artifactId>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 
     <properties>
         <maven.test.skip>true</maven.test.skip>

--- a/qa/pom.xml
+++ b/qa/pom.xml
@@ -127,7 +127,7 @@
                                     </run>
                                 </image>
                                 <image>
-                                    <alias>broker</alias>
+                                    <alias>kapua-broker</alias>
                                     <name>kapua/kapua-broker:1.3.0-SNAPSHOT</name>
                                     <run>
                                         <ports>
@@ -160,13 +160,13 @@
                                             <port>8443:8443</port>
                                         </ports>
                                         <dependsOn>
-                                            <container>broker</container>
+                                            <container>kapua-broker</container>
                                             <container>db</container>
                                             <container>es</container>
                                             <container>events-broker</container>
                                         </dependsOn>
                                         <links>
-                                            <link>broker:broker</link>
+                                            <link>kapua-broker:kapua-broker</link>
                                             <link>db:db</link>
                                             <link>es:es</link>
                                             <link>events-broker:events-broker</link>
@@ -186,19 +186,19 @@
                                             <port>8444:8443</port>
                                         </ports>
                                         <dependsOn>
-                                            <container>broker</container>
+                                            <container>kapua-broker</container>
                                             <container>db</container>
                                             <container>es</container>
                                             <container>events-broker</container>
                                         </dependsOn>
                                         <links>
-                                            <link>broker:broker</link>
+                                            <link>kapua-broker:kapua-broker</link>
                                             <link>db:db</link>
                                             <link>es:es</link>
                                             <link>events-broker:events-broker</link>
                                         </links>
                                         <wait>
-                                            <log>Starting service modules...DONE</log>
+                                            <log>org.eclipse.jetty.server.Server - Started</log>
                                             <time>60000</time>
                                         </wait>
                                     </run>
@@ -209,7 +209,6 @@
                         <executions>
                             <execution>
                                 <id>start</id>
-                                <!--<phase>pre-integration-test</phase>-->
                                 <phase>generate-test-resources</phase>
                                 <goals>
                                     <goal>start</goal>
@@ -217,7 +216,6 @@
                             </execution>
                             <execution>
                                 <id>stop</id>
-                                <!--<phase>post-integration-test</phase>-->
                                 <phase>prepare-package</phase>
                                 <goals>
                                     <goal>stop</goal>
@@ -232,7 +230,7 @@
                             <argLine>@{argLine} -Xmx1024m</argLine>
                             <systemPropertyVariables>
                                 <cucumber.options>--tags @integration</cucumber.options>
-                                <groups>'!org.eclipse.kapua.test.junit.JUnitTests'</groups>
+                                <groups>'!org.eclipse.kapua.qa.markers.junit.JUnitTests'</groups>
                                 <commons.settings.hotswap>true</commons.settings.hotswap>
                                 <org.eclipse.kapua.qa.noEmbeddedServers>true</org.eclipse.kapua.qa.noEmbeddedServers>
                                 <commons.db.jdbcConnectionUrlResolver>DEFAULT</commons.db.jdbcConnectionUrlResolver>


### PR DESCRIPTION
I have update several things:
 - updated root README.md file
 - updated "runTests.md" file with updated commands
 - updated pom files

This should fix issues 2993, 2994 and 2995.

**Related Issue**
This PR fixes/closes _2993_, _2994_ and _2995_

**Description of the solution adopted**
In general documentation (root README.md file) some minor syntax errors have been fixed.
In "runTests.md" file the commands for runnind pure JUnit tests has been fixed.

Because integration tests in dockerized environment were not working (docker containers have started in every submodule)
I changed the pom.xml files of qa/integration, qa/integration-steps, qa/commons and qa/markers modules. Now eveything works fine,
user is again able to run tests from his local machine.

**Screenshots**
/

**Any side note on the changes made**
/

Signed-off-by: Leonardo Gaube <leonardo.gaube@endava.com>